### PR TITLE
be13_api-related changes for bulk_extractor+lightgrep work

### DIFF
--- a/bulk_extractor_i.h
+++ b/bulk_extractor_i.h
@@ -84,7 +84,6 @@ namespace be13 {
 #include "feature_recorder.h"
 #include "feature_recorder_set.h"
 
-
 /* Network includes */
 
 /****************************************************************
@@ -884,6 +883,8 @@ inline std::string safe_utf16to8(std::wstring s){ // needs to be cleaned up
     return utf8_line;
 }
 
+// truncate string at the matching char
+void truncate_at(string &line, char ch);
 
 #ifndef HAVE_ISXDIGIT
 inline int isxdigit(int c)

--- a/feature_recorder.cpp
+++ b/feature_recorder.cpp
@@ -251,7 +251,7 @@ string feature_recorder::unquote_string(const string &s)
  *  Create a histogram for this feature recorder and an extraction pattern.
  */
 
-static void truncate_at(string &line,char ch)
+void truncate_at(string &line,char ch)
 {
     size_t pos = line.find(ch);
     if(pos!=string::npos) line.erase(pos);


### PR DESCRIPTION
This pull request needs to be accepted in turn with the bulk_extractor pull request.

The change here is that I've removed static linkage from truncate_at() in feature_recorder_set.cpp, so it will be exposed, and I've put it's definition in bulk_extractor_i.h. Bulk_extractor itself has a duplicate of truncate_at() in another source file, which I have deleted.
