### PR TITLE
Update build-ubuntu-macos.yml

### DIFF
--- a/.github/workflows/build-ubuntu-macos.yml
+++ b/.github/workflows/build-ubuntu-macos.yml
@@ -63,5 +63,5 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
-          gcov-9 -o . `find . -name '*cpp'`
+          gcov -o . `find . -name '*cpp'`
           bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
gcov-9 seems to have removed in Ubuntu 24